### PR TITLE
Parallel data preprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+.vscode
 vendor
 coverage.out

--- a/search_index_test.go
+++ b/search_index_test.go
@@ -114,7 +114,7 @@ func TestSearchIndex(t *testing.T) {
 	}
 
 	for index, item := range data {
-		searchIndex := NewSearchIndex(searchList, item.Limit, item.Sort, nil, true, nil)
+		searchIndex := NewSearchIndex(searchList, item.Limit, item.Sort, nil, true, nil, 10)
 
 		result := searchIndex.Search(SearchParams{Text: item.Search, OutputSize: item.PageSize, Matching: Beginning})
 


### PR DESCRIPTION
I found that data preprocessing in the AppendData method takes much more time than the other code in this method.
So we can parallelize data preprocessing.
The thread count can be specified in the  `appendThreadsCount` property (1 by default).
